### PR TITLE
PC Parity.

### DIFF
--- a/include/CustomTypes/DownloadQueueViewController.hpp
+++ b/include/CustomTypes/DownloadQueueViewController.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "DownloadSongsSearchViewController.hpp"
+#include "HMUI/FlowCoordinator.hpp"
+#include "HMUI/ViewController.hpp"
+#include "questui/shared/CustomTypes/Components/Backgroundable.hpp"
+#include "questui/shared/BeatSaberUI.hpp"
+
+DECLARE_CLASS_CODEGEN(SongDownloader, DownloadQueueViewController, HMUI::ViewController,
+      DECLARE_OVERRIDE_METHOD(void, DidActivate, il2cpp_utils::FindMethodUnsafe("HMUI", "ViewController", "DidActivate", 3), bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling);
+      DECLARE_OVERRIDE_METHOD(void, DidDeactivate, il2cpp_utils::FindMethodUnsafe("HMUI", "ViewController", "DidDeactivate", 3), bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling);
+
+      DECLARE_INSTANCE_FIELD(UnityEngine::GameObject*, scrollView);
+public:
+    static SongDownloader::DownloadQueueViewController* instance;
+    static void PushDownload(SongDownloader::SearchEntry* entry);
+)
+
+DECLARE_CLASS_CODEGEN(SongDownloader, DownloadItem, UnityEngine::MonoBehaviour,
+    DECLARE_INSTANCE_METHOD(void, Update);
+
+    DECLARE_INSTANCE_FIELD(TMPro::TextMeshProUGUI*, text);
+    DECLARE_INSTANCE_FIELD(TMPro::TextMeshProUGUI*, authorText);
+    DECLARE_INSTANCE_FIELD(HMUI::ImageView*, background);
+public:
+    SongDownloader::SearchEntry* entry;
+    bool hasDone;
+    float timer;
+    float waitTime = 2.0f;
+)
+

--- a/include/CustomTypes/DownloadSongsFlowCoordinator.hpp
+++ b/include/CustomTypes/DownloadSongsFlowCoordinator.hpp
@@ -4,6 +4,7 @@
 #include "HMUI/ViewController.hpp"
 
 #include "DownloadSongsOptionsViewController.hpp"
+#include "DownloadQueueViewController.hpp"
 #include "DownloadSongsSearchViewController.hpp"
 
 #include "custom-types/shared/macros.hpp"
@@ -12,6 +13,7 @@ DECLARE_CLASS_CODEGEN(SongDownloader, DownloadSongsFlowCoordinator, HMUI::FlowCo
 
     DECLARE_INSTANCE_FIELD(SongDownloader::DownloadSongsOptionsViewController*, DownloadSongsOptionsViewController);
     DECLARE_INSTANCE_FIELD(SongDownloader::DownloadSongsSearchViewController*, DownloadSongsSearchViewController);
+    DECLARE_INSTANCE_FIELD(SongDownloader::DownloadQueueViewController*, DownloadQueueViewController);
 
     DECLARE_INSTANCE_METHOD(void, Awake);
 

--- a/include/CustomTypes/DownloadSongsSearchViewController.hpp
+++ b/include/CustomTypes/DownloadSongsSearchViewController.hpp
@@ -40,7 +40,6 @@ namespace SongDownloader {
         UnityEngine::GameObject* gameObject;
         TMPro::TextMeshProUGUI* line1Component;
         TMPro::TextMeshProUGUI* line2Component;
-        HMUI::ImageView* coverImageView;
         UnityEngine::UI::Button* downloadButton;
 
     public:        
@@ -51,6 +50,8 @@ namespace SongDownloader {
         };
 
         float downloadProgress = -1.0f;
+
+        bool pushed = false;
 
         SearchEntry(UnityEngine::GameObject* _gameObject, TMPro::TextMeshProUGUI* _line1Component, TMPro::TextMeshProUGUI* _line2Component, HMUI::ImageView* _coverImageView, UnityEngine::UI::Button* _downloadButton);
 
@@ -73,7 +74,9 @@ namespace SongDownloader {
         void Disable();
 
         bool IsEnabled();
-    }; 
+
+        HMUI::ImageView* coverImageView;
+    };
 
 }
 

--- a/src/CustomTypes/DownloadQueueViewController.cpp
+++ b/src/CustomTypes/DownloadQueueViewController.cpp
@@ -1,0 +1,137 @@
+
+#include "CustomTypes/DownloadQueueViewController.hpp"
+
+#include "questui/shared/BeatSaberUI.hpp"
+#include "questui/shared/CustomTypes/Components/Backgroundable.hpp"
+
+#include "UnityEngine/RectOffset.hpp"
+
+#include "HMUI/ViewController_AnimationDirection.hpp"
+#include "HMUI/ViewController_AnimationType.hpp"
+
+#include "UnityEngine/Mathf.hpp"
+#include "UnityEngine/Rect.hpp"
+#include "UnityEngine/SpriteMeshType.hpp"
+#include "UnityEngine/Texture2D.hpp"
+#include "UnityEngine/RectTransform.hpp"
+#include "UnityEngine/Vector2.hpp"
+#include "UnityEngine/Resources.hpp"
+#include "UnityEngine/Events/UnityAction.hpp"
+#include "UnityEngine/Resources.hpp"
+#include "HMUI/ScrollView.hpp"
+#include "HMUI/Touchable.hpp"
+#include "System/Action.hpp"
+
+#include "GlobalNamespace/LevelBar.hpp"
+
+#include "questui/shared/CustomTypes/Components/ExternalComponents.hpp"
+#include "questui/shared/QuestUI.hpp"
+
+//#include <sstream>
+//#include <iosfwd>
+//#include <iomanip>
+
+using namespace QuestUI;
+using namespace UnityEngine;
+using namespace UnityEngine::UI;
+using namespace UnityEngine::Events;
+using namespace HMUI;
+using namespace TMPro;
+using namespace GlobalNamespace;
+
+using namespace SongDownloader;
+
+DEFINE_TYPE(SongDownloader, DownloadQueueViewController);
+DEFINE_TYPE(SongDownloader, DownloadItem);
+
+void DownloadItem::Update() {
+    if(entry && text) {
+        if(entry->downloadProgress >= 100.0f && hasDone) {
+            hasDone = true;
+            text->SetText("Downloaded!");
+            Destroy(authorText);
+            if (timer > waitTime)
+            {
+                timer = timer - waitTime;
+                Destroy(get_gameObject());
+            }
+        } else {
+//            std::stringstream stream;
+//            stream << std::fixed << std::setprecision(2) << entry->downloadProgress;
+//            std::string s = stream.str();
+            // C++ wont have std::pingpong until C++24, and Mathf::PingPong is stripped so here is a crude implementation
+            auto t = 1.0F - std::abs(UnityEngine::Mathf::Repeat(entry->downloadProgress * 0.35f, 1.0F*2.0F) - 1.0F);
+            UnityEngine::Color color = UnityEngine::Color::HSVToRGB(t, 1, 1);
+            color.a = 0.35f;
+            background->set_color(color);
+            background->set_fillAmount(entry->downloadProgress);
+//            text->SetText(s);
+        }
+    }
+}
+
+void DownloadQueueViewController::PushDownload(SongDownloader::SearchEntry *entry) {
+    if(entry->pushed) return;
+
+    auto imgSprite = entry->coverImageView->get_sprite();
+
+    HorizontalLayoutGroup *horizontalLayoutGroup = BeatSaberUI::CreateHorizontalLayoutGroup(instance->scrollView->get_transform());
+    auto dlItem = horizontalLayoutGroup->get_gameObject()->AddComponent<DownloadItem*>();
+
+    auto image = BeatSaberUI::CreateImage(horizontalLayoutGroup->get_transform(), imgSprite);
+
+    image->get_rectTransform()->set_anchoredPosition({5, 0});
+    image->get_rectTransform()->set_anchorMin({0, 0});
+    image->get_rectTransform()->set_anchorMax({0, 1});
+
+    auto layoutElm = image->GetComponent<LayoutElement*>();
+    if(!layoutElm) layoutElm = image->get_gameObject()->AddComponent<LayoutElement*>();
+    layoutElm->GetComponent<LayoutElement*>()->set_preferredWidth(4);
+    layoutElm->GetComponent<LayoutElement*>()->set_preferredHeight(4);
+
+    auto bgImage = image->get_gameObject()->AddComponent<HMUI::ImageView*>();
+    bgImage->set_enabled(true);
+    bgImage->set_sprite(Sprite::CreateSprite(Texture2D::New_ctor(1, 1), {0, 0, 1, 1}, Vector2::get_one() / 2.0f, 1, 0, SpriteMeshType::_get_FullRect(), Vector4::get_one(), false));
+    bgImage->set_type(UnityEngine::UI::Image::Type::_get_Filled());
+    bgImage->set_fillMethod(UnityEngine::UI::Image::FillMethod::_get_Horizontal());
+    bgImage->set_fillAmount(0.0f);
+    bgImage->set_material(Resources::FindObjectsOfTypeAll<Material*>().First([](Material* x) { return x->get_name() == "UINoGlow"; }));
+
+    dlItem->background = bgImage;
+
+    auto subHorizontal = BeatSaberUI::CreateHorizontalLayoutGroup(horizontalLayoutGroup->get_transform());
+    subHorizontal->set_childForceExpandWidth(true);
+    subHorizontal->set_childControlWidth(false);
+    subHorizontal->get_rectTransform()->set_anchoredPosition({11, 0});
+    subHorizontal->GetComponent<LayoutElement*>()->set_preferredWidth(80);
+
+    auto vert = BeatSaberUI::CreateVerticalLayoutGroup(subHorizontal->get_transform());
+    vert->get_rectTransform()->set_anchoredPosition({20});
+    vert->get_rectTransform()->set_anchorMin({0, 0});
+    vert->get_rectTransform()->set_anchorMax({0, 0});
+    vert->set_childAlignment(TextAnchor::_get_MiddleLeft());
+    vert->GetComponent<ContentSizeFitter*>()->set_verticalFit(ContentSizeFitter::FitMode::_get_PreferredSize());
+
+    dlItem->text = BeatSaberUI::CreateText(vert, string_format("<size=4>%s</size>", entry->GetBeatmap().GetName().c_str()));
+    dlItem->authorText = BeatSaberUI::CreateText(vert, string_format("<size=3>%s</size>", entry->GetBeatmap().GetCurator()->c_str()));
+}
+
+void DownloadQueueViewController::DidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
+    if(firstActivation) {
+        auto titleLayoutGroup = BeatSaberUI::CreateHorizontalLayoutGroup(get_transform());
+        titleLayoutGroup->get_rectTransform()->set_anchorMin({0, 1});
+        titleLayoutGroup->GetComponent<Backgroundable *>()->ApplyBackground("panel-top");
+        titleLayoutGroup->set_padding(RectOffset::New_ctor(10, 10, 0, 0));
+
+        auto text = BeatSaberUI::CreateText(titleLayoutGroup->get_transform(),"<size=8>Download Queue</size>");
+        text->set_alignment(TextAlignmentOptions::Center);
+
+        auto downloadLayoutGroup = QuestUI::BeatSaberUI::CreateVerticalLayoutGroup(get_transform());
+
+        scrollView = QuestUI::BeatSaberUI::CreateScrollView(downloadLayoutGroup->get_transform());
+    }
+}
+
+void DownloadQueueViewController::DidDeactivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
+    this->instance = nullptr;
+}

--- a/src/CustomTypes/DownloadSongsFlowCoordinator.cpp
+++ b/src/CustomTypes/DownloadSongsFlowCoordinator.cpp
@@ -17,13 +17,15 @@ void DownloadSongsFlowCoordinator::Awake(){
         DownloadSongsOptionsViewController = BeatSaberUI::CreateViewController<SongDownloader::DownloadSongsOptionsViewController*>();
     if(!DownloadSongsSearchViewController)
         DownloadSongsSearchViewController = BeatSaberUI::CreateViewController<SongDownloader::DownloadSongsSearchViewController*>();
+    if(!DownloadQueueViewController)
+        DownloadQueueViewController = BeatSaberUI::CreateViewController<SongDownloader::DownloadQueueViewController*>();
 }
 
 void DownloadSongsFlowCoordinator::DidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling){
     if(firstActivation){
         SetTitle(il2cpp_utils::newcsstr("Download Songs"), HMUI::ViewController::AnimationType::In);
         showBackButton = true;
-        ProvideInitialViewControllers(DownloadSongsSearchViewController, DownloadSongsOptionsViewController, nullptr, nullptr, nullptr);
+        ProvideInitialViewControllers(DownloadSongsSearchViewController, DownloadSongsOptionsViewController, nullptr, DownloadQueueViewController, nullptr);
     }
 }
 

--- a/src/CustomTypes/SearchEntry.cpp
+++ b/src/CustomTypes/SearchEntry.cpp
@@ -1,4 +1,5 @@
 #include "CustomTypes/DownloadSongsSearchViewController.hpp"
+#include "CustomTypes/DownloadQueueViewController.hpp"
 
 using namespace QuestUI;
 using namespace UnityEngine;
@@ -208,18 +209,24 @@ void SearchEntry::UpdateDownloadProgress(bool checkLoaded) {
             }
         }
     }
-    if (downloadProgress <= -1.0f) {
-        BeatSaberUI::SetButtonText(downloadButton, "Download");
-        downloadButton->set_interactable(true);
+
+    if(DownloadQueueViewController::instance != nullptr && pushed) {
+        pushed = true;
+        DownloadQueueViewController::PushDownload(this);
     }
-    else if (downloadProgress >= 100.0f) {
-        BeatSaberUI::SetButtonText(downloadButton, "Loaded");
-        downloadButton->set_interactable(false);
-    }
-    else {
-        BeatSaberUI::SetButtonText(downloadButton, string_format("%.0f%%", downloadProgress));
-        downloadButton->set_interactable(false);
-    }
+
+//    if (downloadProgress <= -1.0f) {
+//        BeatSaberUI::SetButtonText(downloadButton, "Download");
+//        downloadButton->set_interactable(true);
+//    }
+//    else if (downloadProgress >= 100.0f) {
+//        BeatSaberUI::SetButtonText(downloadButton, "Loaded");
+//        downloadButton->set_interactable(false);
+//    }
+//    else {
+//        BeatSaberUI::SetButtonText(downloadButton, string_format("%.0f%%", downloadProgress));
+//        downloadButton->set_interactable(false);
+//    }
 }
 
 void SearchEntry::Disable() {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -30,6 +30,8 @@ extern "C" void load() {
     il2cpp_functions::Init();
     QuestUI::Init();
     custom_types::Register::AutoRegister();
-    QuestUI::Register::RegisterMainMenuModSettingsFlowCoordinator<SongDownloader::DownloadSongsFlowCoordinator*>(modInfo);
+
+    QuestUI::Register::RegisterMainMenuModSettingsFlowCoordinator<SongDownloader::DownloadSongsFlowCoordinator*>(modInfo, "More Songs");
+
     LOG_INFO("Successfully installed SongDownloader!");
 }


### PR DESCRIPTION
Aims to create some parity with the PC SongDownloader, simplifying support and wiki pages.

Changes:

- Main Menu Button is now `More Songs` instead of `SongDownloader`
- Download Queue (on bottom viewcontroller because apparently right viewcontroller is used by PlaylistManager)