### PR TITLE
Remove : from allowed characters in FixIlegalName

### DIFF
--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -3,7 +3,7 @@
 namespace FileUtils {
 
     std::string FixIlegalName(std::string_view path) {
-        static const std::string allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890()[]{}%&.:,;=!-_ ";
+        static const std::string allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890()[]{}%&.,;=!-_ ";
         std::string newPath;
         newPath.reserve(path.size());  
         std::copy_if(path.cbegin(), path.cend(), std::back_inserter(newPath), 


### PR DESCRIPTION
For some reason zip extract can't find or create folders with this name, so it's an easy way out, fixes some song downloads with :