### PR TITLE
Set a default value for user stats to prevent error in scenario where the user has no stats

### DIFF
--- a/shared/Types/BeatSaver/UserStats.hpp
+++ b/shared/Types/BeatSaver/UserStats.hpp
@@ -5,13 +5,13 @@
 namespace BeatSaver {
     DECLARE_JSON_CLASS(UserStats,
         ERROR_CHECK
-        GETTER_VALUE(int, TotalUpvotes, "totalUpvotes");
-        GETTER_VALUE(int, TotalDownvotes, "totalDownvotes");
-        GETTER_VALUE(int, TotalMaps, "totalMaps");
-        GETTER_VALUE(int, RankedMaps, "rankedMaps");
-        GETTER_VALUE(float, AvgBpm, "avgBpm");
-        GETTER_VALUE(float, AvgScore, "avgScore");
-        GETTER_VALUE(float, AvgDuration, "avgDuration");
+        GETTER_VALUE_DEFAULT(int, TotalUpvotes, 0, "totalUpvotes");
+        GETTER_VALUE_DEFAULT(int, TotalDownvotes, 0, "totalDownvotes");
+        GETTER_VALUE_DEFAULT(int, TotalMaps, 0, "totalMaps");
+        GETTER_VALUE_DEFAULT(int, RankedMaps, 0, "rankedMaps");
+        GETTER_VALUE_DEFAULT(float, AvgBpm, 0.0f, "avgBpm");
+        GETTER_VALUE_DEFAULT(float, AvgScore, 0.0f, "avgScore");
+        GETTER_VALUE_DEFAULT(float, AvgDuration, 0.0f, "avgDuration");
         GETTER_VALUE_OPTIONAL(std::string, FirstUpload, "firstUpload");
         GETTER_VALUE_OPTIONAL(std::string, LastUpload, "lastUpload");
         GETTER_VALUE(BeatSaver::UserDiffStats, DiffStats, "diffStats");


### PR DESCRIPTION
Set a default value for user stats to prevent error in scenario where the user has no stats.

In some scenarios, the stats object on the user looks like this:
```
"stats": {
  "diffStats": {
    "total": 0,
    "easy": 0,
    "normal": 0,
    "hard": 0,
    "expert": 0,
    "expertPlus": 0
  }
},
```

To fix the issue, we want to set a default value for these parameters to prevent the mod from throwing the error ".stats.totalUpvotes not found error"

Fixes #20