### PR TITLE
Unity 6 update

### DIFF
--- a/mod.template.json
+++ b/mod.template.json
@@ -5,7 +5,7 @@
   "author": "darknight1050, EnderdracheLP, Metalit",
   "version": "${version}",
   "packageId": "com.beatgames.beatsaber",
-  "packageVersion": "1.40.8_7379",
+  "packageVersion": "1.41.0_11623",
   "description": "Download Custom Songs at Runtime",
   "coverImage": "cover.png",
   "dependencies": [],

--- a/qpm.json
+++ b/qpm.json
@@ -6,7 +6,7 @@
   "info": {
     "name": "SongDownloader",
     "id": "songdownloader",
-    "version": "0.8.7",
+    "version": "0.9.0",
     "url": "https://github.com/darknight1050/SongDownloader",
     "additionalData": {
       "overrideSoName": "libsongdownloader.so",
@@ -27,7 +27,7 @@
         "pwsh ./createqmod.ps1 SongDownloader"
       ]
     },
-    "ndk": "^27.2.12479018",
+    "ndk": "^27.3.13750724",
     "qmodIncludeDirs": [
       "build",
       "extern/libs"
@@ -38,27 +38,27 @@
   "dependencies": [
     {
       "id": "beatsaber-hook",
-      "versionRange": "^6.4.2",
+      "versionRange": "^7.4.0",
       "additionalData": {}
     },
     {
       "id": "bs-cordl",
-      "versionRange": "4008.*",
+      "versionRange": "^4100.0",
       "additionalData": {}
     },
     {
       "id": "bsml",
-      "versionRange": "^0.4.54",
+      "versionRange": "^0.6.0",
       "additionalData": {}
     },
     {
       "id": "config-utils",
-      "versionRange": "^2.0.3",
+      "versionRange": "^2.1.0",
       "additionalData": {}
     },
     {
       "id": "custom-types",
-      "versionRange": "^0.18.3",
+      "versionRange": "^0.19.0",
       "additionalData": {}
     },
     {
@@ -73,12 +73,12 @@
     },
     {
       "id": "playlistcore",
-      "versionRange": "^1.5.3",
+      "versionRange": "^1.6.0",
       "additionalData": {}
     },
     {
       "id": "rapidjson-macros",
-      "versionRange": "^2.1.0",
+      "versionRange": "^2.2.0",
       "additionalData": {}
     },
     {
@@ -91,7 +91,7 @@
     },
     {
       "id": "songcore",
-      "versionRange": "^1.1.23",
+      "versionRange": "^1.2.0",
       "additionalData": {}
     }
   ]

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -7,7 +7,7 @@
     "info": {
       "name": "SongDownloader",
       "id": "songdownloader",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "url": "https://github.com/darknight1050/SongDownloader",
       "additionalData": {
         "overrideSoName": "libsongdownloader.so",
@@ -28,7 +28,7 @@
           "pwsh ./createqmod.ps1 SongDownloader"
         ]
       },
-      "ndk": "^27.2.12479018",
+      "ndk": "^27.3.13750724",
       "qmodIncludeDirs": [
         "build",
         "extern/libs"
@@ -39,27 +39,27 @@
     "dependencies": [
       {
         "id": "beatsaber-hook",
-        "versionRange": "^6.4.2",
+        "versionRange": "^7.4.0",
         "additionalData": {}
       },
       {
         "id": "bs-cordl",
-        "versionRange": "4008.*",
+        "versionRange": "^4100.0",
         "additionalData": {}
       },
       {
         "id": "bsml",
-        "versionRange": "^0.4.54",
+        "versionRange": "^0.6.0",
         "additionalData": {}
       },
       {
         "id": "config-utils",
-        "versionRange": "^2.0.3",
+        "versionRange": "^2.1.0",
         "additionalData": {}
       },
       {
         "id": "custom-types",
-        "versionRange": "^0.18.3",
+        "versionRange": "^0.19.0",
         "additionalData": {}
       },
       {
@@ -74,12 +74,12 @@
       },
       {
         "id": "playlistcore",
-        "versionRange": "^1.5.3",
+        "versionRange": "^1.6.0",
         "additionalData": {}
       },
       {
         "id": "rapidjson-macros",
-        "versionRange": "^2.1.0",
+        "versionRange": "^2.2.0",
         "additionalData": {}
       },
       {
@@ -92,7 +92,7 @@
       },
       {
         "id": "songcore",
-        "versionRange": "^1.1.23",
+        "versionRange": "^1.2.0",
         "additionalData": {}
       }
     ]
@@ -101,41 +101,28 @@
     {
       "dependency": {
         "id": "beatsaverplusplus",
-        "versionRange": "=0.2.1",
+        "versionRange": "=0.2.3",
         "additionalData": {
-          "soLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.1/libbeatsaverplusplus.so",
-          "debugSoLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.1/debug_libbeatsaverplusplus.so",
+          "soLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.3/libbeatsaverplusplus.so",
+          "debugSoLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.3/debug_libbeatsaverplusplus.so",
           "overrideSoName": "libbeatsaverplusplus.so",
-          "modLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.1/BeatSaverPlusPlus.qmod",
-          "branchName": "version/v0_2_1",
+          "modLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.3/BeatSaverPlusPlus.qmod",
+          "branchName": "version/v0_2_3",
           "cmake": false
         }
       },
-      "version": "0.2.1"
+      "version": "0.2.3"
     },
     {
       "dependency": {
-        "id": "bs-cordl",
-        "versionRange": "=4008.0.0",
+        "id": "metacore",
+        "versionRange": "=1.7.0",
         "additionalData": {
-          "headersOnly": true,
-          "branchName": "version/v4008_0_0",
-          "compileOptions": {
-            "includePaths": [
-              "include"
-            ],
-            "cppFeatures": [],
-            "cppFlags": [
-              "-DNEED_UNSAFE_CSHARP",
-              "-fdeclspec",
-              "-DUNITY_2021",
-              "-DHAS_CODEGEN",
-              "-Wno-invalid-offsetof"
-            ]
-          }
+          "overrideSoName": "libmetacore.so",
+          "cmake": true
         }
       },
-      "version": "4008.0.0"
+      "version": "1.7.0"
     },
     {
       "dependency": {
@@ -154,17 +141,27 @@
     },
     {
       "dependency": {
-        "id": "metacore",
-        "versionRange": "=1.4.0",
+        "id": "bs-cordl",
+        "versionRange": "=4100.0.1",
         "additionalData": {
-          "soLink": "https://github.com/Metalit/MetaCore/releases/download/v1.4.0/libmetacore.so",
-          "overrideSoName": "libmetacore.so",
-          "modLink": "https://github.com/Metalit/MetaCore/releases/download/v1.4.0/MetaCore.qmod",
-          "branchName": "version/v1_4_0",
-          "cmake": true
+          "headersOnly": true,
+          "branchName": "version/v4100_0_1",
+          "compileOptions": {
+            "includePaths": [
+              "include"
+            ],
+            "cppFeatures": [],
+            "cppFlags": [
+              "-DNEED_UNSAFE_CSHARP",
+              "-fdeclspec",
+              "-DUNITY_6",
+              "-DHAS_CODEGEN",
+              "-Wno-invalid-offsetof"
+            ]
+          }
         }
       },
-      "version": "1.4.0"
+      "version": "4100.0.1"
     },
     {
       "dependency": {
@@ -188,17 +185,17 @@
     {
       "dependency": {
         "id": "web-utils",
-        "versionRange": "=0.6.7",
+        "versionRange": "=0.6.8",
         "additionalData": {
-          "soLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.7/libweb-utils.so",
-          "debugSoLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.7/debug_libweb-utils.so",
+          "soLink": "https://github.com/bsq-ports/WebUtils/releases/download/v0.6.8/libweb-utils.so",
+          "debugSoLink": "https://github.com/bsq-ports/WebUtils/releases/download/v0.6.8/debug_libweb-utils.so",
           "overrideSoName": "libweb-utils.so",
-          "modLink": "https://github.com/RedBrumbler/WebUtils/releases/download/v0.6.7/WebUtils.qmod",
-          "branchName": "version/v0_6_7",
+          "modLink": "https://github.com/bsq-ports/WebUtils/releases/download/v0.6.8/WebUtils.qmod",
+          "branchName": "version/v0_6_8",
           "cmake": false
         }
       },
-      "version": "0.6.7"
+      "version": "0.6.8"
     },
     {
       "dependency": {
@@ -215,8 +212,22 @@
     },
     {
       "dependency": {
+        "id": "flamingo",
+        "versionRange": "=1.1.2",
+        "additionalData": {
+          "soLink": "https://github.com/sc2ad/Flamingo/releases/download/v1.1.2/libflamingo.so",
+          "debugSoLink": "https://github.com/sc2ad/Flamingo/releases/download/v1.1.2/debug_libflamingo.so",
+          "overrideSoName": "libflamingo.so",
+          "modLink": "https://github.com/sc2ad/Flamingo/releases/download/v1.1.2/flamingo.qmod",
+          "branchName": "version/v1_1_2"
+        }
+      },
+      "version": "1.1.2"
+    },
+    {
+      "dependency": {
         "id": "libil2cpp",
-        "versionRange": "=0.4.0",
+        "versionRange": "=0.5.0",
         "additionalData": {
           "headersOnly": true,
           "compileOptions": {
@@ -227,18 +238,14 @@
           }
         }
       },
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     {
       "dependency": {
         "id": "custom-types",
-        "versionRange": "=0.18.3",
+        "versionRange": "=0.19.0",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.18.3/libcustom-types.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.18.3/debug_libcustom-types.so",
           "overrideSoName": "libcustom-types.so",
-          "modLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.18.3/CustomTypes.qmod",
-          "branchName": "version/v0_18_3",
           "compileOptions": {
             "cppFlags": [
               "-Wno-invalid-offsetof"
@@ -247,29 +254,28 @@
           "cmake": true
         }
       },
-      "version": "0.18.3"
+      "version": "0.19.0"
     },
     {
       "dependency": {
         "id": "rapidjson-macros",
-        "versionRange": "=2.1.0",
+        "versionRange": "=2.2.0",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version/v2_1_0",
           "cmake": false
         }
       },
-      "version": "2.1.0"
+      "version": "2.2.0"
     },
     {
       "dependency": {
         "id": "paper2_scotland2",
-        "versionRange": "=4.6.4",
+        "versionRange": "=4.7.0",
         "additionalData": {
-          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/libpaper2_scotland2.so",
+          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.7.0/libpaper2_scotland2.so",
           "overrideSoName": "libpaper2_scotland2.so",
-          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/paper2_scotland2.qmod",
-          "branchName": "version/v4_6_4",
+          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.7.0/paper2_scotland2.qmod",
+          "branchName": "version/v4_7_0",
           "compileOptions": {
             "systemIncludes": [
               "shared/utfcpp/source"
@@ -278,21 +284,19 @@
           "cmake": false
         }
       },
-      "version": "4.6.4"
+      "version": "4.7.0"
     },
     {
       "dependency": {
         "id": "config-utils",
-        "versionRange": "=2.0.3",
+        "versionRange": "=2.1.0",
         "additionalData": {
           "headersOnly": true,
-          "soLink": "https://github.com/darknight1050/config-utils/releases/download/v2.0.3/libconfig-utils_test.so",
           "overrideSoName": "libconfig-utils_test.so",
-          "branchName": "version/v2_0_3",
           "cmake": true
         }
       },
-      "version": "2.0.3"
+      "version": "2.1.0"
     },
     {
       "dependency": {
@@ -310,26 +314,23 @@
     {
       "dependency": {
         "id": "playlistcore",
-        "versionRange": "=1.5.5",
+        "versionRange": "=1.6.0",
         "additionalData": {
-          "soLink": "https://github.com/Metalit/PlaylistCore/releases/download/v1.5.5/libplaylistcore.so",
-          "overrideSoName": "libplaylistcore.so",
-          "modLink": "https://github.com/Metalit/PlaylistCore/releases/download/v1.5.5/PlaylistCore.qmod",
-          "branchName": "version/v1_5_5"
+          "overrideSoName": "libplaylistcore.so"
         }
       },
-      "version": "1.5.5"
+      "version": "1.6.0"
     },
     {
       "dependency": {
         "id": "beatsaber-hook",
-        "versionRange": "=6.4.2",
+        "versionRange": "=7.4.0",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v6.4.2/libbeatsaber-hook.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v6.4.2/debug_libbeatsaber-hook.so",
+          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v7.4.0/libbeatsaber-hook.so",
+          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v7.4.0/debug_libbeatsaber-hook.so",
           "overrideSoName": "libbeatsaber-hook.so",
-          "modLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v6.4.2/beatsaber-hook.qmod",
-          "branchName": "version/v6_4_2",
+          "modLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v7.4.0/beatsaber-hook.qmod",
+          "branchName": "version/v7_4_0",
           "compileOptions": {
             "cppFlags": [
               "-Wno-extra-qualification"
@@ -338,37 +339,29 @@
           "cmake": true
         }
       },
-      "version": "6.4.2"
+      "version": "7.4.0"
     },
     {
       "dependency": {
         "id": "bsml",
-        "versionRange": "=0.4.55",
+        "versionRange": "=0.6.0",
         "additionalData": {
-          "soLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/libbsml.so",
-          "debugSoLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/debug_libbsml.so",
           "overrideSoName": "libbsml.so",
-          "modLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/BSML.qmod",
-          "branchName": "version/v0_4_55",
           "cmake": true
         }
       },
-      "version": "0.4.55"
+      "version": "0.6.0"
     },
     {
       "dependency": {
         "id": "songcore",
-        "versionRange": "=1.1.24",
+        "versionRange": "=1.2.0",
         "additionalData": {
-          "soLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/libsongcore.so",
-          "debugSoLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/debug_libsongcore.so",
           "overrideSoName": "libsongcore.so",
-          "modLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/SongCore.qmod",
-          "branchName": "version/v1_1_24",
           "cmake": true
         }
       },
-      "version": "1.1.24"
+      "version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
# Before PR can be set to ready
- [ ] update qpm.json to use release versions
   - [ ] custom-types: `^0.19.0`
   - [ ] bsml: `^0.6.0`
   - [ ] config-utils: `^2.1.0`
   - [ ] rapidjson-macros: `^3.0.0`
   - [ ] songcore: `^1.2.0`
   - [ ] playlistcore: `^1.6.0`

## blocked by PRs
* https://github.com/QuestPackageManager/Il2CppQuestTypePatching/pull/22
* https://github.com/bsq-ports/Quest-BSML/pull/17
* https://github.com/darknight1050/config-utils/pull/17
* https://github.com/Metalit/RapidjsonMacros/pull/3
* https://github.com/bsq-ports/Quest-BSML/pull/17
* https://github.com/Metalit/PlaylistCore/pull/18
* https://github.com/raineaeternal/Quest-SongCore/tree/dev/unity6